### PR TITLE
chore: add Arch PKGBUILD and packaging instructions

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = muralis
+pkgdesc = Minimal wallpaper shuffler for X11 and Sway
+pkgver = 0.5.0
+pkgrel = 1
+url = https://github.com/OWNER/muralis
+arch = any
+license = GPL2
+depends = bash
+depends = coreutils
+depends = findutils
+optdepends = feh: wallpaper setting on X11
+optdepends = xorg-xrandr: monitor detection on X11
+optdepends = xorg-xev: watch mode on X11
+optdepends = sway: Wayland compositor support
+optdepends = jq: JSON parsing for sway backend
+optdepends = dialog: terminal GUI
+optdepends = whiptail: terminal GUI
+optdepends = fzf: fuzzy finder GUI
+source = https://github.com/OWNER/muralis/archive/refs/tags/v0.5.0.tar.gz
+sha256sums = SKIP
+
+pkgname = muralis

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore build artifacts
+src/
+pkg/
+*.tar.*
+*.pkg.tar.*
+
+*.log
+
+# Editor backups
+*~
+*.swp

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=muralis
+pkgver=0.5.0
+pkgrel=1
+pkgdesc="Minimal wallpaper shuffler for X11 and Sway"
+arch=('any')
+url="https://github.com/OWNER/muralis"
+license=('GPL2')
+depends=('bash' 'coreutils' 'findutils')
+optdepends=('feh: wallpaper setting on X11'
+            'xorg-xrandr: monitor detection on X11'
+            'xorg-xev: watch mode on X11'
+            'sway: Wayland compositor support'
+            'jq: JSON parsing for sway backend'
+            'dialog: terminal GUI'
+            'whiptail: terminal GUI'
+            'fzf: fuzzy finder GUI')
+source=("https://github.com/OWNER/muralis/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+package() {
+  cd "${srcdir}/muralis-${pkgver}"
+  install -Dm755 muralis.sh "${pkgdir}/usr/bin/muralis"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
 # muralis
-**muralis** is a minimal, flexible wallpaper manager for X11, serving as a CLI/GUI wrapper for `feh`. Originally created for an i3 setup, it’s ideal for users seeking a lightweight, easily configurable solution for multi-monitor environments.
+**muralis** is a minimal, flexible wallpaper manager for X11 and Wayland. It uses `feh` on X11 and `swaymsg` on Wayland. Originally created for an i3 setup, it now targets compatibility with any desktop environment, display manager, or window manager.
 
 Key features:
 
-- **Multi-monitor support:** Uses XRandR to detect displays and allows both per-monitor and global wallpaper directories.
+- **Multi-monitor support:** Uses XRandR or Wayland output queries to detect displays and allows both per-monitor and global wallpaper directories.
 - **Randomized wallpapers:** Automatically selects and sets random backgrounds.
 - **Automation:** Integrates with systemd user services and timers to change wallpapers at configurable intervals.
-- **Easy setup:** Includes an Arch PKGBUILD, systemd unit files, and shell completions.
+- **Easy setup:** Build from source or install via an Arch PKGBUILD.
+- **Broad compatibility:** Works across X11 and Wayland setups, making it suitable for virtually any desktop environment, display manager, or window manager.
 
 muralis is designed for simplicity and minimalism, making it easy to keep your desktop fresh with minimal resource usage.
+
+## Installation
+
+### Arch Linux
+
+An example `PKGBUILD` is provided. To build and install:
+
+```sh
+makepkg -si
+```
+
+When publishing to the AUR, replace `OWNER` in the `source` URL with your GitHub username.
+
+### From source
+
+Run the script directly or install into `~/.local/bin`:
+
+```sh
+./muralis.sh --install
+```


### PR DESCRIPTION
## Summary
- add PKGBUILD and .SRCINFO to enable Arch Linux packaging
- document Arch build steps and ignore build artifacts

## Testing
- `shellcheck muralis.sh` (warnings: SC2034, SC2206, SC2015, SC2086)
- `./muralis.sh --help`
- `makepkg --printsrcinfo` (fails: unknown error, missing pacman)


------
https://chatgpt.com/codex/tasks/task_e_6898e7211d68832abb5f8426a6449d40