### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=muralis
-pkgver=0.5.0
+pkgver=1.0.0
 pkgrel=1
 pkgdesc="Minimal wallpaper shuffler for X11 and Sway"
 arch=('any')

--- a/muralis.sh
+++ b/muralis.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.5.0"
+version="1.0.0"
 
 install_self() {
     target_dir="$HOME/.local/bin"


### PR DESCRIPTION
## Summary
- update version string in muralis.sh to 1.0.0
- bump PKGBUILD pkgver to 1.0.0

## Testing
- `bash -n muralis.sh`
- `bash -n PKGBUILD`
- `./muralis.sh -V`


------
https://chatgpt.com/codex/tasks/task_e_6898ef2b8fa4832aa270868f9e6f9029